### PR TITLE
Add TR4 socket

### DIFF
--- a/specs/AMD-CPUs/Ryzen.yaml
+++ b/specs/AMD-CPUs/Ryzen.yaml
@@ -7,6 +7,7 @@ data:
   Lithography: 14 nm
   Sockets:
     - AM4
+    - TR4
 sections:
   - header: THREADRIPPER
     members:


### PR DESCRIPTION
If the "Ryzen" category encompasses the "Threadripper" CPUs as well, its socket should be listed.