### PR TITLE
Improve README.md on Ubuntu/Debian

### DIFF
--- a/specs/AMD-GPUs/R-300.yaml
+++ b/specs/AMD-GPUs/R-300.yaml
@@ -22,7 +22,8 @@ sections:
   - header: MID RANGE
     members:
       - R9-380X
-      - R9-380
+      - R9-380-4GiB
+      - R9-380-2GiB
       - R9-370X-4GiB
       - R9-370X-2GiB
       - R7-370-4GiB


### PR DESCRIPTION
Version of nodejs on Ubuntu 16.xx is too old for build to succeed.
Installation of the latest nodejs taken from https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions
Also fixed a typo.